### PR TITLE
Cmake include only lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+result
+result-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.25)
+project(antithesis-sdk-cpp VERSION $ENV{version} LANGUAGES CXX)
+
+
+add_library(antithesis-sdk-cpp INTERFACE antithesis_sdk.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.25)
 project(antithesis-sdk-cpp VERSION $ENV{version} LANGUAGES CXX)
 
-
 add_library(antithesis-sdk-cpp INTERFACE antithesis_sdk.h)

--- a/antithesis-sdk-cpp.nix
+++ b/antithesis-sdk-cpp.nix
@@ -1,35 +1,10 @@
-# antithesis-sdk-cpp.nix
-
 {stdenv, pkgs}:
-# let
-# in
   with pkgs;
   stdenv.mkDerivation {
     pname = "antithesis-sdk-cpp";
-    version = "0.1.1";
+    version = "0.2.2";
 
     src = ./.;
-
-    nativeBuildInputs = [
-      clang_17
-      cmake
-    ];
-
-    # buildInputs = [];
-
-    configurePhase = ''
-      cmake .
-    '';
-
-    # patchPhase = '' '';
-
-    buildPhase = ''
-      #env
-      make antithesis-sdk-cpp
-      #ls -lR 
-    '';
-
-    # checkPhase = '' '';
 
     installPhase = ''
       mkdir -p $out/include

--- a/antithesis-sdk-cpp.nix
+++ b/antithesis-sdk-cpp.nix
@@ -1,0 +1,39 @@
+# antithesis-sdk-cpp.nix
+
+{stdenv, pkgs}:
+# let
+# in
+  with pkgs;
+  stdenv.mkDerivation {
+    pname = "antithesis-sdk-cpp";
+    version = "0.1.1";
+
+    src = ./.;
+
+    nativeBuildInputs = [
+      clang_17
+      cmake
+    ];
+
+    # buildInputs = [];
+
+    configurePhase = ''
+      cmake .
+    '';
+
+    # patchPhase = '' '';
+
+    buildPhase = ''
+      #env
+      make antithesis-sdk-cpp
+      #ls -lR 
+    '';
+
+    # checkPhase = '' '';
+
+    installPhase = ''
+      mkdir -p $out/include
+      cp antithesis_sdk.h $out/include/antithesis_sdk.h
+    '';
+
+  }

--- a/antithesis_sdk.h
+++ b/antithesis_sdk.h
@@ -606,13 +606,13 @@ void load_libvoidstar() {
 
     void* trace_pc_guard_init_sym = dlsym(shared_lib, "__sanitizer_cov_trace_pc_guard_init");
     if (!trace_pc_guard_init_sym) {
-        message_out("Can access trace_pc_guard symbol __sanitizer_cov_trace_pc_guard_init\n");
+        message_out("Can not forward calls to libvoidstar for __sanitizer_cov_trace_pc_guard_init\n");
         return;
     }
 
     void* trace_pc_guard_sym = dlsym(shared_lib, "__sanitizer_cov_trace_pc_guard");
     if (!trace_pc_guard_sym) {
-        message_out("Can access trace_pc_guard symbol __sanitizer_cov_trace_pc_guard\n");
+        message_out("Can not forward calls to libvoidstar for __sanitizer_cov_trace_pc_guard\n");
         return;
     }
 
@@ -628,7 +628,7 @@ void load_libvoidstar() {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 extern "C" void __sanitizer_cov_trace_pc_guard_init(uint32_t *start, uint32_t *stop) {
-    message_out("STUB: __sanitizer_cov_trace_pc_guard_init()\n");
+    message_out("SDK forwarding to libvoidstar for __sanitizer_cov_trace_pc_guard_init()\n");
     if (!did_check_libvoidstar) {
         load_libvoidstar();
     }

--- a/antithesis_sdk.h
+++ b/antithesis_sdk.h
@@ -12,7 +12,7 @@
 #include <vector>
 
 namespace antithesis {
-    inline const char* SDK_VERSION = "0.2.1";
+    inline const char* SDK_VERSION = "0.2.2";
     inline const char* PROTOCOL_VERSION = "1.0.0";
 
     struct LocalRandom {
@@ -78,6 +78,7 @@ namespace antithesis {
 #include <cstdio>
 #include <array>
 #include <source_location>
+#include <iostream>
 #include <sstream>
 #include <iomanip>
 #include <dlfcn.h>
@@ -575,6 +576,79 @@ namespace {
 #define SOMETIMES(cond, message, ...) ANTITHESIS_ASSERT_RAW(antithesis::SOMETIMES_ASSERTION, cond, message, __VA_ARGS__)
 #define REACHABLE(message, ...) ANTITHESIS_ASSERT_RAW(antithesis::REACHABLE_ASSERTION, true, message, __VA_ARGS__)
 #define UNREACHABLE(message, ...) ANTITHESIS_ASSERT_RAW(antithesis::UNREACHABLE_ASSERTION, false, message, __VA_ARGS__)
+
+
+// If the libvoidstar(determ) library is present, 
+// pass thru trace_pc_guard related callbacks to it
+typedef void (*trace_pc_guard_init_fn)(uint32_t *start, uint32_t *stop);
+typedef void (*trace_pc_guard_fn)(uint32_t *guard);
+
+static trace_pc_guard_init_fn trace_pc_guard_init = nullptr;
+static trace_pc_guard_fn trace_pc_guard = nullptr;
+static bool did_check_libvoidstar = false;
+static bool has_libvoidstar = false;
+
+void message_out(const char *msg) {
+  write(1, msg, strlen(msg));
+  return;
+}
+
+void load_libvoidstar() {
+    if (did_check_libvoidstar) {
+      return;
+    }
+    did_check_libvoidstar = true;
+    void* shared_lib = dlopen(antithesis::LIB_PATH, RTLD_NOW);
+    if (!shared_lib) {
+        message_out("Can not load the Antithesis native library\n");
+        return;
+    }
+
+    void* trace_pc_guard_init_sym = dlsym(shared_lib, "__sanitizer_cov_trace_pc_guard_init");
+    if (!trace_pc_guard_init_sym) {
+        message_out("Can access trace_pc_guard symbol __sanitizer_cov_trace_pc_guard_init\n");
+        return;
+    }
+
+    void* trace_pc_guard_sym = dlsym(shared_lib, "__sanitizer_cov_trace_pc_guard");
+    if (!trace_pc_guard_sym) {
+        message_out("Can access trace_pc_guard symbol __sanitizer_cov_trace_pc_guard\n");
+        return;
+    }
+
+    trace_pc_guard_init = reinterpret_cast<trace_pc_guard_init_fn>(trace_pc_guard_init_sym);
+    trace_pc_guard = reinterpret_cast<trace_pc_guard_fn>(trace_pc_guard_sym);
+    has_libvoidstar = true;
+}
+
+// The following symbols are indeed reserved identifiers, since we're implementing functions defined
+// in the compiler runtime. Not clear how to get Clang on board with that besides narrowly suppressing
+// the warning in this case. The sample code on the CoverageSanitizer documentation page fails this 
+// warning!
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+extern "C" void __sanitizer_cov_trace_pc_guard_init(uint32_t *start, uint32_t *stop) {
+    message_out("STUB: __sanitizer_cov_trace_pc_guard_init()\n");
+    if (!did_check_libvoidstar) {
+        load_libvoidstar();
+    }
+    if (has_libvoidstar) {
+        trace_pc_guard_init(start, stop);
+    }
+    return;
+}
+
+extern "C" void __sanitizer_cov_trace_pc_guard( uint32_t *guard ) {
+    if (has_libvoidstar) {
+        trace_pc_guard(guard);
+    } else {
+        if (guard) {
+          *guard = 0;
+        }
+    }
+    return;
+}
+#pragma clang diagnostic pop
 
 #endif
 

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,3 @@
-# default.nix
-
 let pkgs = import <nixpkgs> { }; in
 {
   antithesis-sdk-cpp = pkgs.callPackage ./antithesis-sdk-cpp.nix  { stdenv = pkgs.clangStdenv; };

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,6 @@
+# default.nix
+
+let pkgs = import <nixpkgs> { }; in
+{
+  antithesis-sdk-cpp = pkgs.callPackage ./antithesis-sdk-cpp.nix  { stdenv = pkgs.clangStdenv; };
+} 


### PR DESCRIPTION
Add implementations of  __sanitizer_cov_trace_pc_guard_init and __sanitizer_cov_trace_pc_guard in the antithesis_sdk.h header file

Dynamically load dlopen the libvoidstar.so library and call the functions there.

https://trello.com/c/Oxy7FdCF/1693-c-sdk-plus-instrumentation
