### PR TITLE
add inline to funcs defined in header

### DIFF
--- a/antithesis_sdk.h
+++ b/antithesis_sdk.h
@@ -588,12 +588,12 @@ static trace_pc_guard_fn trace_pc_guard = nullptr;
 static bool did_check_libvoidstar = false;
 static bool has_libvoidstar = false;
 
-void message_out(const char *msg) {
+inline void message_out(const char *msg) {
   write(1, msg, strlen(msg));
   return;
 }
 
-void load_libvoidstar() {
+inline void load_libvoidstar() {
     if (did_check_libvoidstar) {
       return;
     }
@@ -627,7 +627,7 @@ void load_libvoidstar() {
 // warning!
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreserved-identifier"
-extern "C" void __sanitizer_cov_trace_pc_guard_init(uint32_t *start, uint32_t *stop) {
+extern "C" inline void __sanitizer_cov_trace_pc_guard_init(uint32_t *start, uint32_t *stop) {
     message_out("SDK forwarding to libvoidstar for __sanitizer_cov_trace_pc_guard_init()\n");
     if (!did_check_libvoidstar) {
         load_libvoidstar();
@@ -638,7 +638,7 @@ extern "C" void __sanitizer_cov_trace_pc_guard_init(uint32_t *start, uint32_t *s
     return;
 }
 
-extern "C" void __sanitizer_cov_trace_pc_guard( uint32_t *guard ) {
+extern "C" inline void __sanitizer_cov_trace_pc_guard( uint32_t *guard ) {
     if (has_libvoidstar) {
         trace_pc_guard(guard);
     } else {


### PR DESCRIPTION
If the sdk header was included in multiple files there would be link errors saying `message_out`, `load_libvoidstar`, etc was defined multiple times. Adding inline seems to fix it