### PR TITLE
split out instrumentation into its own header file

### DIFF
--- a/antithesis-sdk-cpp.nix
+++ b/antithesis-sdk-cpp.nix
@@ -2,13 +2,14 @@
   with pkgs;
   stdenv.mkDerivation {
     pname = "antithesis-sdk-cpp";
-    version = "0.2.3";
+    version = "0.2.4";
 
     src = ./.;
 
     installPhase = ''
       mkdir -p $out/include
       cp antithesis_sdk.h $out/include/antithesis_sdk.h
+      cp antithesis_instrumentation.h $out/include/antithesis_instrumentation.h
     '';
 
   }

--- a/antithesis-sdk-cpp.nix
+++ b/antithesis-sdk-cpp.nix
@@ -2,7 +2,7 @@
   with pkgs;
   stdenv.mkDerivation {
     pname = "antithesis-sdk-cpp";
-    version = "0.2.4";
+    version = "0.3.0";
 
     src = ./.;
 

--- a/antithesis_instrumentation.h
+++ b/antithesis_instrumentation.h
@@ -1,10 +1,14 @@
 #pragma once
 
-// This header file contains the instrumentation part of the Antithesis C++ SDK.
-// This header file (but not the remainder of the SDK) can be used in either C or C++ programs. You should include it in *a single*
-// .cpp or .c file to add instrumentation to your project (there are also compiler command-line arguments to set).
-//
-// Documentation for the SDK, including how to use this is found at https://antithesis.com/docs/using_antithesis/sdk/cpp_sdk.html.
+/*
+This header file enables code coverage instrumentation. It is distributed with the Antithesis C++ SDK.
+
+This header file can be used in both C and C++ programs. (The rest of the SDK works only for C++ programs.)
+
+You should include it in a single .cpp or .c file.
+
+The instructions (such as required compiler flags) and usage guidance are found at https://antithesis.com/docs/using_antithesis/sdk/cpp_sdk.html.
+*/
 
 #include <unistd.h>
 #include <string.h>

--- a/antithesis_instrumentation.h
+++ b/antithesis_instrumentation.h
@@ -1,31 +1,41 @@
 #pragma once
 
-// This header file contains the Antithesis C++ SDK, which enables C++ applications to integrate with the [Antithesis platform].
+// This header file contains the instrumentation part of the Antithesis C++ SDK.
+// This header file (but not the remainder of the SDK) can be used in either C or C++ programs. You should include it in *a single*
+// .cpp or .c file to add instrumentation to your project (there are also compiler command-line arguments to set).
 //
-// Documentation for the SDK is found at https://antithesis.com/docs/using_antithesis/sdk/cpp_sdk.html.
+// Documentation for the SDK, including how to use this is found at https://antithesis.com/docs/using_antithesis/sdk/cpp_sdk.html.
+
 #include <unistd.h>
 #include <string.h>
 #include <dlfcn.h>
-#include <cstdint>
-
+#include <stdint.h>
+#ifndef __cplusplus
+#include <stdbool.h>
+#include <stddef.h>
+#endif
 
 // If the libvoidstar(determ) library is present, 
 // pass thru trace_pc_guard related callbacks to it
 typedef void (*trace_pc_guard_init_fn)(uint32_t *start, uint32_t *stop);
 typedef void (*trace_pc_guard_fn)(uint32_t *guard);
 
-static trace_pc_guard_init_fn trace_pc_guard_init = nullptr;
-static trace_pc_guard_fn trace_pc_guard = nullptr;
+static trace_pc_guard_init_fn trace_pc_guard_init = NULL;
+static trace_pc_guard_fn trace_pc_guard = NULL;
 static bool did_check_libvoidstar = false;
 static bool has_libvoidstar = false;
 
-inline void message_out(const char *msg) {
-  write(1, msg, strlen(msg));
+static void message_out(const char *msg) {
+  (void)write(1, msg, strlen(msg));
   return;
 }
 
-inline void load_libvoidstar() {
-    constexpr const char* LIB_PATH = "/usr/lib/libvoidstar.so";
+static void load_libvoidstar() {
+#ifdef __cplusplus
+    constexpr
+#endif
+    const char* LIB_PATH = "/usr/lib/libvoidstar.so";
+
     if (did_check_libvoidstar) {
       return;
     }
@@ -48,8 +58,8 @@ inline void load_libvoidstar() {
         return;
     }
 
-    trace_pc_guard_init = reinterpret_cast<trace_pc_guard_init_fn>(trace_pc_guard_init_sym);
-    trace_pc_guard = reinterpret_cast<trace_pc_guard_fn>(trace_pc_guard_sym);
+    trace_pc_guard_init = (trace_pc_guard_init_fn)(trace_pc_guard_init_sym);
+    trace_pc_guard = (trace_pc_guard_fn)(trace_pc_guard_sym);
     has_libvoidstar = true;
 }
 
@@ -59,7 +69,11 @@ inline void load_libvoidstar() {
 // warning!
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreserved-identifier"
-extern "C" void __sanitizer_cov_trace_pc_guard_init(uint32_t *start, uint32_t *stop) {
+extern 
+#ifdef __cplusplus
+    "C"
+#endif
+void __sanitizer_cov_trace_pc_guard_init(uint32_t *start, uint32_t *stop) {
     message_out("SDK forwarding to libvoidstar for __sanitizer_cov_trace_pc_guard_init()\n");
     if (!did_check_libvoidstar) {
         load_libvoidstar();
@@ -70,7 +84,11 @@ extern "C" void __sanitizer_cov_trace_pc_guard_init(uint32_t *start, uint32_t *s
     return;
 }
 
-extern "C" void __sanitizer_cov_trace_pc_guard( uint32_t *guard ) {
+extern 
+#ifdef __cplusplus
+    "C"
+#endif
+void __sanitizer_cov_trace_pc_guard( uint32_t *guard ) {
     if (has_libvoidstar) {
         trace_pc_guard(guard);
     } else {

--- a/antithesis_instrumentation.h
+++ b/antithesis_instrumentation.h
@@ -64,8 +64,8 @@ extern  __attribute__((no_sanitize("coverage"))) void antithesis_load_libvoidsta
         return;
     }
 
-    trace_pc_guard_init = reinterpret_cast<trace_pc_guard_init_fn>(trace_pc_guard_init_sym);
-    trace_pc_guard = reinterpret_cast<trace_pc_guard_fn>(trace_pc_guard_sym);
+    trace_pc_guard_init = (trace_pc_guard_init_fn)(trace_pc_guard_init_sym);
+    trace_pc_guard = (trace_pc_guard_fn)(trace_pc_guard_sym);
     has_libvoidstar = true;
     debug_message_out("LOADED libvoidstar");
 }
@@ -97,7 +97,7 @@ extern
 #endif
 void __sanitizer_cov_trace_pc_guard( uint32_t *guard ) {
     if (has_libvoidstar) {
-        auto edge = reinterpret_cast<uint64_t>(__builtin_return_address(0));
+        uint64_t edge = (uint64_t)(__builtin_return_address(0));
         trace_pc_guard(guard, edge);
     } else {
         if (guard) {

--- a/antithesis_instrumentation.h
+++ b/antithesis_instrumentation.h
@@ -62,7 +62,7 @@ __attribute__((no_sanitize("coverage"))) void antithesis_load_libvoidstar() {
         return;
     }
 
-    void* trace_pc_guard_sym = dlsym(shared_lib, "trace_pc_guard_sdk");
+    void* trace_pc_guard_sym = dlsym(shared_lib, "__sanitizer_cov_trace_pc_guard_internal");
     if (!trace_pc_guard_sym) {
         debug_message_out("Can not forward calls to libvoidstar for __sanitizer_cov_trace_pc_guard");
         return;

--- a/antithesis_instrumentation.h
+++ b/antithesis_instrumentation.h
@@ -35,7 +35,11 @@ static __attribute__((no_sanitize("coverage"))) void debug_message_out(const cha
   return;
 }
 
-extern  __attribute__((no_sanitize("coverage"))) void antithesis_load_libvoidstar() {
+extern
+#ifdef __cplusplus
+    "C"
+#endif
+__attribute__((no_sanitize("coverage"))) void antithesis_load_libvoidstar() {
 #ifdef __cplusplus
     constexpr
 #endif

--- a/antithesis_instrumentation.h
+++ b/antithesis_instrumentation.h
@@ -25,12 +25,12 @@ static trace_pc_guard_fn trace_pc_guard = NULL;
 static bool did_check_libvoidstar = false;
 static bool has_libvoidstar = false;
 
-static void message_out(const char *msg) {
-  (void)write(1, msg, strlen(msg));
+static void debug_message_out(const char *msg) {
+  //(void)write(1, msg, strlen(msg));
   return;
 }
 
-static void load_libvoidstar() {
+extern void antithesis_load_libvoidstar() {
 #ifdef __cplusplus
     constexpr
 #endif
@@ -42,19 +42,19 @@ static void load_libvoidstar() {
     did_check_libvoidstar = true;
     void* shared_lib = dlopen(LIB_PATH, RTLD_NOW);
     if (!shared_lib) {
-        message_out("Can not load the Antithesis native library\n");
+        debug_message_out("Can not load the Antithesis native library\n");
         return;
     }
 
     void* trace_pc_guard_init_sym = dlsym(shared_lib, "__sanitizer_cov_trace_pc_guard_init");
     if (!trace_pc_guard_init_sym) {
-        message_out("Can not forward calls to libvoidstar for __sanitizer_cov_trace_pc_guard_init\n");
+        debug_message_out("Can not forward calls to libvoidstar for __sanitizer_cov_trace_pc_guard_init\n");
         return;
     }
 
     void* trace_pc_guard_sym = dlsym(shared_lib, "__sanitizer_cov_trace_pc_guard");
     if (!trace_pc_guard_sym) {
-        message_out("Can not forward calls to libvoidstar for __sanitizer_cov_trace_pc_guard\n");
+        debug_message_out("Can not forward calls to libvoidstar for __sanitizer_cov_trace_pc_guard\n");
         return;
     }
 
@@ -74,9 +74,9 @@ extern
     "C"
 #endif
 void __sanitizer_cov_trace_pc_guard_init(uint32_t *start, uint32_t *stop) {
-    message_out("SDK forwarding to libvoidstar for __sanitizer_cov_trace_pc_guard_init()\n");
+    debug_message_out("SDK forwarding to libvoidstar for __sanitizer_cov_trace_pc_guard_init()\n");
     if (!did_check_libvoidstar) {
-        load_libvoidstar();
+        antithesis_load_libvoidstar();
     }
     if (has_libvoidstar) {
         trace_pc_guard_init(start, stop);

--- a/antithesis_instrumentation.h
+++ b/antithesis_instrumentation.h
@@ -1,0 +1,83 @@
+#pragma once
+
+// This header file contains the Antithesis C++ SDK, which enables C++ applications to integrate with the [Antithesis platform].
+//
+// Documentation for the SDK is found at https://antithesis.com/docs/using_antithesis/sdk/cpp_sdk.html.
+#include <unistd.h>
+#include <string.h>
+#include <dlfcn.h>
+#include <cstdint>
+
+
+// If the libvoidstar(determ) library is present, 
+// pass thru trace_pc_guard related callbacks to it
+typedef void (*trace_pc_guard_init_fn)(uint32_t *start, uint32_t *stop);
+typedef void (*trace_pc_guard_fn)(uint32_t *guard);
+
+static trace_pc_guard_init_fn trace_pc_guard_init = nullptr;
+static trace_pc_guard_fn trace_pc_guard = nullptr;
+static bool did_check_libvoidstar = false;
+static bool has_libvoidstar = false;
+
+inline void message_out(const char *msg) {
+  write(1, msg, strlen(msg));
+  return;
+}
+
+inline void load_libvoidstar() {
+    constexpr const char* LIB_PATH = "/usr/lib/libvoidstar.so";
+    if (did_check_libvoidstar) {
+      return;
+    }
+    did_check_libvoidstar = true;
+    void* shared_lib = dlopen(LIB_PATH, RTLD_NOW);
+    if (!shared_lib) {
+        message_out("Can not load the Antithesis native library\n");
+        return;
+    }
+
+    void* trace_pc_guard_init_sym = dlsym(shared_lib, "__sanitizer_cov_trace_pc_guard_init");
+    if (!trace_pc_guard_init_sym) {
+        message_out("Can not forward calls to libvoidstar for __sanitizer_cov_trace_pc_guard_init\n");
+        return;
+    }
+
+    void* trace_pc_guard_sym = dlsym(shared_lib, "__sanitizer_cov_trace_pc_guard");
+    if (!trace_pc_guard_sym) {
+        message_out("Can not forward calls to libvoidstar for __sanitizer_cov_trace_pc_guard\n");
+        return;
+    }
+
+    trace_pc_guard_init = reinterpret_cast<trace_pc_guard_init_fn>(trace_pc_guard_init_sym);
+    trace_pc_guard = reinterpret_cast<trace_pc_guard_fn>(trace_pc_guard_sym);
+    has_libvoidstar = true;
+}
+
+// The following symbols are indeed reserved identifiers, since we're implementing functions defined
+// in the compiler runtime. Not clear how to get Clang on board with that besides narrowly suppressing
+// the warning in this case. The sample code on the CoverageSanitizer documentation page fails this 
+// warning!
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+extern "C" void __sanitizer_cov_trace_pc_guard_init(uint32_t *start, uint32_t *stop) {
+    message_out("SDK forwarding to libvoidstar for __sanitizer_cov_trace_pc_guard_init()\n");
+    if (!did_check_libvoidstar) {
+        load_libvoidstar();
+    }
+    if (has_libvoidstar) {
+        trace_pc_guard_init(start, stop);
+    }
+    return;
+}
+
+extern "C" void __sanitizer_cov_trace_pc_guard( uint32_t *guard ) {
+    if (has_libvoidstar) {
+        trace_pc_guard(guard);
+    } else {
+        if (guard) {
+          *guard = 0;
+        }
+    }
+    return;
+}
+#pragma clang diagnostic pop

--- a/antithesis_sdk.h
+++ b/antithesis_sdk.h
@@ -12,7 +12,7 @@
 #include <vector>
 
 namespace antithesis {
-    inline const char* SDK_VERSION = "0.2.3";
+    inline const char* SDK_VERSION = "0.2.4";
     inline const char* PROTOCOL_VERSION = "1.0.0";
 
     struct LocalRandom {
@@ -129,19 +129,19 @@ namespace antithesis {
 
             void* fuzz_json_data = dlsym(shared_lib, "fuzz_json_data");
             if (!fuzz_json_data) {
-                error("Can access symbol fuzz_json_data");
+                error("Can not access symbol fuzz_json_data");
                 return nullptr;
             }
 
             void* fuzz_flush = dlsym(shared_lib, "fuzz_flush");
             if (!fuzz_flush) {
-                error("Can access symbol fuzz_flush");
+                error("Can not access symbol fuzz_flush");
                 return nullptr;
             }
 
             void* fuzz_get_random = dlsym(shared_lib, "fuzz_get_random");
             if (!fuzz_get_random) {
-                error("Can access symbol fuzz_get_random");
+                error("Can not access symbol fuzz_get_random");
                 return nullptr;
             }
 
@@ -576,79 +576,6 @@ namespace {
 #define SOMETIMES(cond, message, ...) ANTITHESIS_ASSERT_RAW(antithesis::SOMETIMES_ASSERTION, cond, message, __VA_ARGS__)
 #define REACHABLE(message, ...) ANTITHESIS_ASSERT_RAW(antithesis::REACHABLE_ASSERTION, true, message, __VA_ARGS__)
 #define UNREACHABLE(message, ...) ANTITHESIS_ASSERT_RAW(antithesis::UNREACHABLE_ASSERTION, false, message, __VA_ARGS__)
-
-
-// If the libvoidstar(determ) library is present, 
-// pass thru trace_pc_guard related callbacks to it
-typedef void (*trace_pc_guard_init_fn)(uint32_t *start, uint32_t *stop);
-typedef void (*trace_pc_guard_fn)(uint32_t *guard);
-
-static trace_pc_guard_init_fn trace_pc_guard_init = nullptr;
-static trace_pc_guard_fn trace_pc_guard = nullptr;
-static bool did_check_libvoidstar = false;
-static bool has_libvoidstar = false;
-
-inline void message_out(const char *msg) {
-  write(1, msg, strlen(msg));
-  return;
-}
-
-inline void load_libvoidstar() {
-    if (did_check_libvoidstar) {
-      return;
-    }
-    did_check_libvoidstar = true;
-    void* shared_lib = dlopen(antithesis::LIB_PATH, RTLD_NOW);
-    if (!shared_lib) {
-        message_out("Can not load the Antithesis native library\n");
-        return;
-    }
-
-    void* trace_pc_guard_init_sym = dlsym(shared_lib, "__sanitizer_cov_trace_pc_guard_init");
-    if (!trace_pc_guard_init_sym) {
-        message_out("Can not forward calls to libvoidstar for __sanitizer_cov_trace_pc_guard_init\n");
-        return;
-    }
-
-    void* trace_pc_guard_sym = dlsym(shared_lib, "__sanitizer_cov_trace_pc_guard");
-    if (!trace_pc_guard_sym) {
-        message_out("Can not forward calls to libvoidstar for __sanitizer_cov_trace_pc_guard\n");
-        return;
-    }
-
-    trace_pc_guard_init = reinterpret_cast<trace_pc_guard_init_fn>(trace_pc_guard_init_sym);
-    trace_pc_guard = reinterpret_cast<trace_pc_guard_fn>(trace_pc_guard_sym);
-    has_libvoidstar = true;
-}
-
-// The following symbols are indeed reserved identifiers, since we're implementing functions defined
-// in the compiler runtime. Not clear how to get Clang on board with that besides narrowly suppressing
-// the warning in this case. The sample code on the CoverageSanitizer documentation page fails this 
-// warning!
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wreserved-identifier"
-extern "C" inline void __sanitizer_cov_trace_pc_guard_init(uint32_t *start, uint32_t *stop) {
-    message_out("SDK forwarding to libvoidstar for __sanitizer_cov_trace_pc_guard_init()\n");
-    if (!did_check_libvoidstar) {
-        load_libvoidstar();
-    }
-    if (has_libvoidstar) {
-        trace_pc_guard_init(start, stop);
-    }
-    return;
-}
-
-extern "C" inline void __sanitizer_cov_trace_pc_guard( uint32_t *guard ) {
-    if (has_libvoidstar) {
-        trace_pc_guard(guard);
-    } else {
-        if (guard) {
-          *guard = 0;
-        }
-    }
-    return;
-}
-#pragma clang diagnostic pop
 
 #endif
 

--- a/antithesis_sdk.h
+++ b/antithesis_sdk.h
@@ -12,7 +12,7 @@
 #include <vector>
 
 namespace antithesis {
-    inline const char* SDK_VERSION = "0.2.4";
+    inline const char* SDK_VERSION = "0.3.0";
     inline const char* PROTOCOL_VERSION = "1.0.0";
 
     struct LocalRandom {


### PR DESCRIPTION
Instead of the sdk including the instrumentation functions we split them out to its own header. This will need to be included only once in the project.