### PR TITLE
Add default constructor to antithesis::JSON

### DIFF
--- a/antithesis_sdk.h
+++ b/antithesis_sdk.h
@@ -39,6 +39,8 @@ namespace antithesis {
     typedef std::variant<BasicValueType, JSON_ARRAY> ValueType;
 
     struct JSON : std::map<std::string, ValueType> {
+        JSON() : std::map<std::string, ValueType>() {}
+
         JSON( std::initializer_list<std::pair<const std::string, ValueType>> args) : std::map<std::string, ValueType>(args) {}
 
         JSON( std::initializer_list<std::pair<const std::string, ValueType>> args, std::vector<std::pair<const std::string, ValueType>> more_args ) : std::map<std::string, ValueType>(args) {


### PR DESCRIPTION
This will allow skipping the last parameter in the instrumentation macros, instead of using a dummy `{}`