### PR TITLE
Make `<antithesis_sdk.h>` more friendly for projects which don't always use it

### DIFF
--- a/antithesis_sdk.h
+++ b/antithesis_sdk.h
@@ -60,11 +60,13 @@ namespace antithesis {
 
 #if defined(NO_ANTITHESIS_SDK) || __cplusplus < 202000L || (defined(__clang__) && __clang_major__ < 16)
 
+#ifndef NO_ANTITHESIS_SDK
 #if __cplusplus < 202000L
     #error "The Antithesis C++ API requires C++20 or higher"
 #endif
 #if defined(__clang__) && __clang_major__ < 16
     #error "The Antithesis C++ API requires clang version 16 or higher"
+#endif
 #endif
 
 #define ALWAYS(cond, message, ...)


### PR DESCRIPTION
Our project is currently guarding `#include <antithesis_sdk.h>` with our own `#define` rather than `#define 
 NO_ANTITHESIS_SDK` and include it always, for two reasons:

* We need our project to build with clang 15 (obviously without Antithesis SDK being used)
* We need appropriate polyfills when Antithesis SDK is not being used

I thought that perhaps other projects are doing the same, in which case it would make sense for `<antithesis_sdk.h>` to do this work for us, rather than us guarding the include. 

It might be that other projects need something else than regular C `assert` for polyfills, in which case an appropriate definition could be added, along the lines:

```
#ifndef ANTITHESIS_SDK_POLYFILL
#include <cassert>
#define ANTITHESIS_SDK_POLYFILL assert
#endif

#define ALWAYS(cond, message, ...) ANTITHESIS_SDK_POLYFILL((message) && (cond))
#define ALWAYS_OR_UNREACHABLE(cond, message, ...) ANTITHESIS_SDK_POLYFILL((message) && (cond))
. . .
```