### PR TITLE
Refactoring and bug fixes

### DIFF
--- a/antithesis_sdk.h
+++ b/antithesis_sdk.h
@@ -906,7 +906,7 @@ namespace { // Anonymous namespace which is translation-unit-specific; certain s
 #define ANTITHESIS_NUMERIC_ASSERT_RAW(name, assertion_type, guidepost_type, left, cmp, right, message, ...) \
 do { \
     static_assert(std::is_same_v<decltype(left), decltype(right)>, "Values compared in " #name " must be of same type"); \
-    ANTITHESIS_ASSERT_RAW(assertion_type, left cmp right, message, __VA_ARGS__, {{ "left", left }, { "right", right }} ); \
+    ANTITHESIS_ASSERT_RAW(assertion_type, left cmp right, message, __VA_ARGS__ __VA_OPT__(,) {{ "left", left }, { "right", right }} ); \
     antithesis::internal::NumericGuidanceCatalogEntry< \
         decltype(left), \
         guidepost_type, \
@@ -952,7 +952,7 @@ do { \
         FIXED_STRING_FROM_C_STR(std::source_location::current().function_name()), \
         std::source_location::current().line(), \
         std::source_location::current().column() \
-    >::assertion.check_assertion(disjunction, (antithesis::JSON(__VA_ARGS__, pairs)) ); \
+    >::assertion.check_assertion(disjunction, (antithesis::JSON(__VA_ARGS__ __VA_OPT__(,) pairs)) ); \
     antithesis::JSON json_pairs = antithesis::JSON(pairs); \
     antithesis::internal::BooleanGuidanceCatalogEntry< \
         decltype(json_pairs), \
@@ -982,7 +982,7 @@ do { \
         FIXED_STRING_FROM_C_STR(std::source_location::current().function_name()), \
         std::source_location::current().line(), \
         std::source_location::current().column() \
-    >::assertion.check_assertion(conjunction, (antithesis::JSON(__VA_ARGS__, pairs)) ); \
+    >::assertion.check_assertion(conjunction, (antithesis::JSON(__VA_ARGS__ __VA_OPT__(,) pairs)) ); \
     antithesis::JSON json_pairs = antithesis::JSON(pairs); \
     BooleanGuidanceCatalogEntry< \
         decltype(json_pairs), \

--- a/antithesis_sdk.h
+++ b/antithesis_sdk.h
@@ -938,7 +938,8 @@ ANTITHESIS_NUMERIC_ASSERT_RAW(SOMETIMES_LESS_THAN_OR_EQUAL_TO, antithesis::inter
 #define ALWAYS_SOME(pairs, message, ...) \
 do { \
     bool disjunction = false; \
-    for (std::pair<std::string, bool> pair : pairs) { \
+    std::vector<std::pair<std::string, bool>> vec_pairs = pairs; \
+    for (std::pair<std::string, bool> pair : vec_pairs) { \
         if (pair.second) { \
             disjunction = true; \
             break; \
@@ -967,7 +968,8 @@ do { \
 #define SOMETIMES_ALL(pairs, message, ...) \
 do { \
     bool conjunction = true; \
-    for (std::pair<std::string, bool> pair : pairs) { \
+    std::vector<std::pair<std::string, bool>> vec_pairs = pairs; \
+    for (std::pair<std::string, bool> pair : vec_pairs) { \
         if (!pair.second) { \
             conjunction = false; \
             break; \


### PR DESCRIPTION
Continue @mgibson-antithesis's refactor that organize code into public/internal namespaces, and fix some issues:
- JSON string escaping should also escape ASCII control characters (`0x00` -- `0x1F`).
- Fix compilation issue with `SOMETIMES_ALL` and `ALWAYS_SOME`.
- Make sure the last argument (`details`) is optional in all assertion macros.

TODO:
- [ ] Bump patch version and cut a new release.