### PR TITLE
Use explicit bool conversion for cond parameter

### DIFF
--- a/antithesis_sdk.h
+++ b/antithesis_sdk.h
@@ -539,12 +539,13 @@ namespace antithesis::internal::assertions {
             }
         }
 
-        [[clang::always_inline]] inline void check_assertion(bool cond, const JSON& details) {
+        [[clang::always_inline]] inline void check_assertion(auto&& cond, const JSON& details)
+            requires requires { static_cast<bool>(std::forward<decltype(cond)>(cond)); } {
             #if defined(NO_ANTITHESIS_SDK)
               #error "Antithesis SDK has been disabled"
             #endif
             if (__builtin_expect(state.false_not_seen || state.true_not_seen, false)) {
-                check_assertion_internal(cond, details);
+                check_assertion_internal(static_cast<bool>(std::forward<decltype(cond)>(cond)), details);
             }
         }
 


### PR DESCRIPTION
The intent is to make it legal to use macros where conversion to bool would be explicit, similar to how C `assert` macro works. For example:

```c++
  auto valid(int config) noexcept -> std::optional<int>;

  auto p = valid(config);
  ALWAYS(p, "Requires valid config value");
```