### PR TITLE
Add ANTITHESIS_MAX_NAME_LEN macro

### DIFF
--- a/antithesis_sdk.h
+++ b/antithesis_sdk.h
@@ -767,6 +767,8 @@ namespace antithesis::internal::assertions {
 
 namespace antithesis::internal {
 namespace { // Anonymous namespace which is translation-unit-specific; certain symbols aren't exposed in the symbol table as a result
+    enum msg_name_e { msg_name };
+
     template <std::size_t N>
     struct fixed_string {
         std::array<char, N> contents;
@@ -776,8 +778,17 @@ namespace { // Anonymous namespace which is translation-unit-specific; certain s
 
         #pragma clang diagnostic push
         #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
+
         constexpr fixed_string( const char (&arr)[N] )
         {
+            for(unsigned int i=0; i<N; i++) contents[i] = arr[i];
+        }
+
+        constexpr fixed_string( const char (&arr)[N], msg_name_e )
+        {
+#ifdef ANTITHESIS_MAX_NAME_LEN
+            static_assert(N <= ANTITHESIS_MAX_NAME_LEN + 1);
+#endif
             for(unsigned int i=0; i<N; i++) contents[i] = arr[i];
         }
 
@@ -794,6 +805,9 @@ namespace { // Anonymous namespace which is translation-unit-specific; certain s
 
     template <std::size_t N>
     fixed_string( const char (&arr)[N] ) -> fixed_string<N>;
+
+    template <std::size_t N>
+    fixed_string( const char (&arr)[N], msg_name_e ) -> fixed_string<N>;
 
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
@@ -935,7 +949,7 @@ namespace { // Anonymous namespace which is translation-unit-specific; certain s
 #define ANTITHESIS_ASSERT_RAW(type, cond, message, ...) ( \
     antithesis::internal::CatalogEntry< \
         type, \
-        antithesis::internal::fixed_string(message), \
+        antithesis::internal::fixed_string(message, antithesis::internal::msg_name), \
         FIXED_STRING_FROM_C_STR(std::source_location::current().file_name()), \
         FIXED_STRING_FROM_C_STR(std::source_location::current().function_name()), \
         std::source_location::current().line(), \
@@ -955,7 +969,7 @@ do { \
     antithesis::internal::NumericGuidanceCatalogEntry< \
         decltype(left), \
         guidepost_type, \
-        antithesis::internal::fixed_string(message), \
+        antithesis::internal::fixed_string(message, antithesis::internal::msg_name), \
         FIXED_STRING_FROM_C_STR(std::source_location::current().file_name()), \
         FIXED_STRING_FROM_C_STR(std::source_location::current().function_name()), \
         std::source_location::current().line(), \
@@ -995,7 +1009,7 @@ do { \
     antithesis::internal::BooleanGuidanceCatalogEntry< \
         decltype(json_pairs), \
         antithesis::internal::assertions::GUIDEPOST_NONE, \
-        antithesis::internal::fixed_string(message), \
+        antithesis::internal::fixed_string(message, antithesis::internal::msg_name), \
         FIXED_STRING_FROM_C_STR(std::source_location::current().file_name()), \
         FIXED_STRING_FROM_C_STR(std::source_location::current().function_name()), \
         std::source_location::current().line(), \
@@ -1018,7 +1032,7 @@ do { \
     antithesis::internal::BooleanGuidanceCatalogEntry< \
         decltype(json_pairs), \
         antithesis::internal::assertions::GUIDEPOST_ALL, \
-        antithesis::internal::fixed_string(message), \
+        antithesis::internal::fixed_string(message, antithesis::internal::msg_name), \
         FIXED_STRING_FROM_C_STR(std::source_location::current().file_name()), \
         FIXED_STRING_FROM_C_STR(std::source_location::current().function_name()), \
         std::source_location::current().line(), \


### PR DESCRIPTION
We have new users defining their own instrumentation points, and they have started using some very long messages, unaware that this may cause readability issues in report and also that these names are stuck "forever" (or until report history is truncated).

This change will enable us to enforce maximum assertion message (name) length.

I tested this with

```c++
#define ANTITHESIS_MAX_NAME_LEN 9

#include "antithesis_sdk.h"

int main() {
  using namespace antithesis;
  REACHABLE("Message 1", {{"a", 1}});
  ALWAYS_OR_UNREACHABLE(false, "Message 2");
  ALWAYS_GREATER_THAN(10, 20, "Hello");
  ALWAYS_SOME(NAMED_LIST(false), "Message");
  SOMETIMES_ALL(NAMED_LIST(false), "Msg");
  return 0;
}
```

I am not planning  to bring this functionality to polyfills, as it would bring lots of extra assumptions into what polyfills are allowed (or not) to do.