### PR TITLE
Remove names from the context of SOMETIMES_ALL and ALWAYS_SOME

### DIFF
--- a/antithesis_sdk.h
+++ b/antithesis_sdk.h
@@ -982,48 +982,40 @@ ANTITHESIS_NUMERIC_ASSERT_RAW(SOMETIMES_LESS_THAN_OR_EQUAL_TO, antithesis::inter
 
 #define ALWAYS_SOME(pairs, message, ...) \
 do { \
-    bool disjunction = false; \
-    std::vector<std::pair<std::string, bool>> vec_pairs = pairs; \
-    for (std::pair<std::string, bool> pair : vec_pairs) { \
-        if (pair.second) { \
-            disjunction = true; \
-            break; \
-        } \
-    } \
-    ANTITHESIS_ASSERT_RAW(antithesis::internal::assertions::ALWAYS_ASSERTION, disjunction, message, __VA_ARGS__ __VA_OPT__(,) pairs); \
-    antithesis::JSON json_pairs = antithesis::JSON(pairs); \
+    ANTITHESIS_ASSERT_RAW(antithesis::internal::assertions::ALWAYS_ASSERTION, ( \
+        [](std::initializer_list<std::pair<std::string, bool>> ps){ \
+            for (auto const& pair : ps) \
+                if (pair.second) return true; \
+            return false; }(pairs)), \
+        message, __VA_ARGS__ __VA_OPT__(,) pairs); \
     antithesis::internal::BooleanGuidanceCatalogEntry< \
-        decltype(json_pairs), \
+        antithesis::JSON, \
         antithesis::internal::assertions::GUIDEPOST_NONE, \
         antithesis::internal::fixed_string(message), \
         FIXED_STRING_FROM_C_STR(std::source_location::current().file_name()), \
         FIXED_STRING_FROM_C_STR(std::source_location::current().function_name()), \
         std::source_location::current().line(), \
         std::source_location::current().column() \
-    >::guidepost.send_guidance(json_pairs); \
+    >::guidepost.send_guidance(antithesis::JSON(pairs)); \
 } while (0)
 
 #define SOMETIMES_ALL(pairs, message, ...) \
 do { \
-    bool conjunction = true; \
-    std::vector<std::pair<std::string, bool>> vec_pairs = pairs; \
-    for (std::pair<std::string, bool> pair : vec_pairs) { \
-        if (!pair.second) { \
-            conjunction = false; \
-            break; \
-        } \
-    } \
-    ANTITHESIS_ASSERT_RAW(antithesis::internal::assertions::SOMETIMES_ASSERTION, conjunction, message, __VA_ARGS__ __VA_OPT__(,) pairs); \
-    antithesis::JSON json_pairs = antithesis::JSON(pairs); \
+    ANTITHESIS_ASSERT_RAW(antithesis::internal::assertions::SOMETIMES_ASSERTION, ( \
+        [](std::initializer_list<std::pair<std::string, bool>> ps){ \
+            for (auto const& pair : ps) \
+                if (!pair.second) return false; \
+            return true; }(pairs)), \
+        message, __VA_ARGS__ __VA_OPT__(,) pairs); \
     antithesis::internal::BooleanGuidanceCatalogEntry< \
-        decltype(json_pairs), \
+        antithesis::JSON, \
         antithesis::internal::assertions::GUIDEPOST_ALL, \
         antithesis::internal::fixed_string(message), \
         FIXED_STRING_FROM_C_STR(std::source_location::current().file_name()), \
         FIXED_STRING_FROM_C_STR(std::source_location::current().function_name()), \
         std::source_location::current().line(), \
         std::source_location::current().column() \
-    >::guidepost.send_guidance(json_pairs); \
+    >::guidepost.send_guidance(antithesis::JSON(pairs)); \
 } while (0)
 
 #endif


### PR DESCRIPTION
Because the C++ (and C) preprocessor always injects names from the immediately surrounding scope into the context of evaluation of macro parameters, any names defined inside the scope owned by the macro definition will have different meaning compared to the identical names outside of this scope. In practice this means that e.g. the following test program will be buggy in several subtle ways, for reasons not immediately obvious to its author or reader.

```c++
#include "antithesis_sdk.h"

int main() {
  constexpr bool vec_pairs = true;
  constexpr bool json_pairs = true;
  constexpr bool disjunction = true;
  ALWAYS_SOME(NAMED_LIST(disjunction, vec_pairs, json_pairs), "");
  constexpr bool conjunction = false;
  SOMETIMES_ALL(NAMED_LIST(conjunction, vec_pairs, json_pairs), "");
  return 0;
}
```

This PR fixes the problem by removing all such names from the scope owned by the macro definition. An alternative solution, [available to C++ implementations only](https://eel.is/c++draft/lex.name#3), would use `__` prefix (or e.g. `_Antithesis`) for such internal names.

Note, this PR also replaces `std::vector<std::pair<std::string, bool>>` with `std::initializer_list<std::pair<std::string, bool>>`. this is incidental.