### PR TITLE
use safe casts for c++

### DIFF
--- a/antithesis_instrumentation.h
+++ b/antithesis_instrumentation.h
@@ -68,8 +68,13 @@ __attribute__((no_sanitize("coverage"))) void antithesis_load_libvoidstar() {
         return;
     }
 
+#ifdef __cplusplus
+    trace_pc_guard_init = reinterpret_cast<trace_pc_guard_init_fn>(trace_pc_guard_init_sym);
+    trace_pc_guard = reinterpret_cast<trace_pc_guard_fn>(trace_pc_guard_sym);
+#else
     trace_pc_guard_init = (trace_pc_guard_init_fn)(trace_pc_guard_init_sym);
     trace_pc_guard = (trace_pc_guard_fn)(trace_pc_guard_sym);
+#endif
     has_libvoidstar = true;
     debug_message_out("LOADED libvoidstar");
 }
@@ -101,7 +106,11 @@ extern
 #endif
 void __sanitizer_cov_trace_pc_guard( uint32_t *guard ) {
     if (has_libvoidstar) {
+#ifdef __cplusplus
+        uint64_t edge = reinterpret_cast<uint64_t>(__builtin_return_address(0));
+#else
         uint64_t edge = (uint64_t)(__builtin_return_address(0));
+#endif
         trace_pc_guard(guard, edge);
     } else {
         if (guard) {


### PR DESCRIPTION
## Problem

When compiling a C++ project with `-Werror`, the current `antithesis_instrumentation.h` fails compilation because of warnings for unrestricted c-style casts.

## Proposed Solution

Add preprocessor blocks conditionally using C++ `reinterpret_cast` only when compiling for a C++ target, preserves compatibility with C.